### PR TITLE
Update requirements.txt for Python 3.13 Compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
-easyocr==1.7.1
-openai==1.58.1
-python-dotenv==1.0.1
-wikipedia==1.4.0
-pillow==10.4.0
-platformdirs==4.2.2
-sympy==1.13.2
-tenacity==9.0.0
 diskcache==5.6.3
-transformers==4.44.2
-pymed==0.8.9
+easyocr==1.7.2
 metapub==0.5.12
+openai==1.64.0
+pillow==11.1.0
+platformdirs==4.3.6
+pymed==0.8.9
+python-dotenv==1.0.1
+sympy==1.13.1
+tenacity==9.0.0
+transformers==4.49.0
+wikipedia==1.4.0
 
 # numpy==2.1.0
 # sympy==1.13.2


### PR DESCRIPTION
Verified that this is backwards compatible with Python 3.9 and 3.10. Without this update, users on Python 3.13 will see the following error:

> INFO: pip is looking at multiple versions of torch to determine which version is compatible with other requirements. This could take a while.
> ERROR: Cannot install easyocr and sympy==1.13.2 because these package versions have conflicting dependencies.
> 
> The conflict is caused by:
> The user requested sympy==1.13.2
> torch 2.6.0 depends on sympy==1.13.1; python_version >= "3.9"
> 
> To fix this you could try to:
> 
> loosen the range of package versions you've specified
> remove package versions to allow pip to attempt to solve the dependency conflict