### PR TITLE
Update solve.py, make sure stop criteria can be triggered.

### DIFF
--- a/tasks/solve.py
+++ b/tasks/solve.py
@@ -241,7 +241,7 @@ class Solver:
                     query_analysis, 
                     self.memory
                 )
-                conclusion = self.planner.extract_conclusion(stop_verification)
+                context_verification, conclusion = self.planner.extract_conclusion(stop_verification)
                 
                 if self.verbose:
                     print(f"\n## [{step_count}] Stopping Verification:")

--- a/tasks/solve.py
+++ b/tasks/solve.py
@@ -246,7 +246,7 @@ class Solver:
                 if self.verbose:
                     print(f"\n## [{step_count}] Stopping Verification:")
                     print("#"*50)
-                    print(f"{stop_verification}")
+                    print(f"{context_verification}")
                     print("#"*50)
                     print(f"\n==>Extracted Conclusion:\n{conclusion}")
 


### PR DESCRIPTION
Hi Author,

I recently tried to reproduce OctoTools results with this repo. However, I found context verifier fail to break the for loop even return the confident conclusion. While examining the code base, I found in `tasks/solve.py`, planner return a tuple which never trigger the stop criteria:
```
# line 244
conclusion = self.planner.extract_conclusion(stop_verification)

if conclusion == 'STOP':
    break
```

Suggestion:
Similar to `octotools/solver.py`, change return object and logging.
```
# line 150
context_verification, conclusion = self.planner.extract_conclusion(stop_verification)
```

Hope this bug fix can help other people while reproducing your results.

