### PR TITLE
Add black and isort to dev deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,16 @@ Arxiv = "https://arxiv.org/pdf/2502.11271"
 Demo = "https://huggingface.co/spaces/OctoTools/octotools"
 Github = "https://github.com/octotools/octotools"
 Issues = "https://github.com/octotools/octotools/issues"
+
+[project.optional-dependencies]
+dev = [
+    "black>=25.1.0",
+    "isort>=6.0.1"
+]
+
+[tool.black]
+line-length = 88
+target-version = ['py310']
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
It's unclear if this change is strictly necessary, but it adds `dev` as an optional project dependency.

In my last PR (https://github.com/octotools/octotools/pull/44), I used it as follows:

```bash
uv sync --extra dev
uv run isort octotools/engine/ollama.py
uv run black octotools/engine/ollama.py
```

This makes it easier to manage formatting tools in development workflows.