### PR TITLE
Update package inclusion pattern in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ license-files = ["LICEN[CS]E*"]
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["octotools"]
+include = ["octotools*"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
Fixes #48.

This fixes package discovery so the built `octotoolkit` distribution includes OctoTools subpackages such as:

- `octotools.models`
- `octotools.engine`
- `octotools.tools`

The current setuptools discovery config uses:

```toml
include = ["octotools"]
```
Setuptools package patterns match full import-style package names, so matching the parent package does not automatically include subpackages. The pattern needs a wildcard to include nested packages.
This PR changes it to:

```toml
include = ["octotools*"]
```

I installed the package from this branch in a downstream environment and verified:

```bash
python - <<'PY'
import octotools
from octotools.models.planner import Planner
from octotools.models.executor import Executor
from octotools.models.memory import Memory
from octotools.tools.base import BaseTool

print("octotools import ok")
print(octotools.__file__)
PY
```

Output: 
```bash
octotools import ok
.../site-packages/octotools/__init__.py
```